### PR TITLE
Add `server.RunOptionsFromParsedFlags` method

### DIFF
--- a/app/server/options.go
+++ b/app/server/options.go
@@ -59,6 +59,11 @@ func RunOptionsFromFlagSet(ctx context.Context, fs *flag.FlagSet) (*RunOptions, 
 	if err != nil {
 		return nil, fmt.Errorf("Failed to assign flags from environment variables, %w", err)
 	}
+	
+	return RunOptionsFromParsedFlags(ctx)
+}
+
+func RunOptionsFromParsedFlags(ctx context.Context, args ...string) (*RunOptions, error) {
 
 	if root_url == "" {
 		root_url = server_uri

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -12,12 +12,12 @@ import (
 	"github.com/aaronland/go-http/v3/server"
 )
 
-func Run(ctx context.Context, logger *slog.Logger) error {
+func Run(ctx context.Context) error {
 	fs := DefaultFlagSet()
-	return RunWithFlagSet(ctx, fs, logger)
+	return RunWithFlagSet(ctx, fs)
 }
 
-func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *slog.Logger) error {
+func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet) error {
 
 	opts, err := RunOptionsFromFlagSet(ctx, fs)
 
@@ -25,12 +25,10 @@ func RunWithFlagSet(ctx context.Context, fs *flag.FlagSet, logger *slog.Logger) 
 		return fmt.Errorf("Failed to derive run options from flagset, %w", err)
 	}
 
-	return RunWithOptions(ctx, opts, logger)
+	return RunWithOptions(ctx, opts)
 }
 
-func RunWithOptions(ctx context.Context, opts *RunOptions, logger *slog.Logger) error {
-
-	slog.SetDefault(logger)
+func RunWithOptions(ctx context.Context, opts *RunOptions) error {
 
 	// First create a local copy of RunOptions that can't be
 	// modified after the fact. 'run_options' is defined in vars.go

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,8 +2,7 @@ package main
 
 import (
 	"context"
-	"log/slog"
-	"os"
+	"log"
 
 	"github.com/whosonfirst/go-whosonfirst-spelunker-httpd/app/server"
 )
@@ -11,12 +10,9 @@ import (
 func main() {
 
 	ctx := context.Background()
-	logger := slog.Default()
-
-	err := server.Run(ctx, logger)
+	err := server.Run(ctx)
 
 	if err != nil {
-		slog.Error("Failed to run server", "error", err)
-		os.Exit(1)
+		log.Fatalf("Failed to run server, %v", err)
 	}
 }


### PR DESCRIPTION
* Add `server.RunOptionsFromParsedFlags` method
* Update `server.Run` method signatures to no longer require `slog.Logger`
* This release is NOT backwards compatible